### PR TITLE
override the language used for translation on a per directive/filter/$translate call

### DIFF
--- a/src/directive/translate.js
+++ b/src/directive/translate.js
@@ -191,6 +191,10 @@ angular.module('pascalprecht.translate')
           scope.defaultText = value;
         });
 
+        iAttr.$observe('translateLanguage', function (value) {
+          scope.requestedLangKey = value;
+        });
+
         if (translateValuesExist) {
           iAttr.$observe('translateValues', function (interpolateParams) {
             if (interpolateParams) {
@@ -219,15 +223,15 @@ angular.module('pascalprecht.translate')
         var updateTranslations = function () {
           for (var key in translationIds) {
             if (translationIds.hasOwnProperty(key)) {
-              updateTranslation(key, translationIds[key], scope, scope.interpolateParams, scope.defaultText);
+              updateTranslation(key, translationIds[key], scope, scope.interpolateParams, scope.defaultText, scope.requestedLangKey);
             }
           }
         };
 
         // Put translation processing function outside loop
-        var updateTranslation = function(translateAttr, translationId, scope, interpolateParams, defaultTranslationText) {
+        var updateTranslation = function(translateAttr, translationId, scope, interpolateParams, defaultTranslationText, requestedLangKey) {
           if (translationId) {
-            $translate(translationId, interpolateParams, translateInterpolation, defaultTranslationText)
+            $translate(translationId, interpolateParams, translateInterpolation, defaultTranslationText, requestedLangKey)
               .then(function (translation) {
                 applyTranslation(translation, scope, true, translateAttr);
               }, function (translationId) {

--- a/src/filter/translate.js
+++ b/src/filter/translate.js
@@ -51,13 +51,13 @@ angular.module('pascalprecht.translate')
    </example>
  */
 .filter('translate', ['$parse', '$translate', function ($parse, $translate) {
-  var translateFilter = function (translationId, interpolateParams, interpolation) {
+  var translateFilter = function (translationId, interpolateParams, interpolation, requestedLangKey) {
 
     if (!angular.isObject(interpolateParams)) {
       interpolateParams = $parse(interpolateParams)(this);
     }
 
-    return $translate.instant(translationId, interpolateParams, interpolation);
+    return $translate.instant(translationId, interpolateParams, interpolation, requestedLangKey);
   };
 
   // Since AngularJS 1.3, filters which are not stateless (depending at the scope)

--- a/test/unit/directive/translate.spec.js
+++ b/test/unit/directive/translate.spec.js
@@ -19,6 +19,10 @@ describe('pascalprecht.translate', function () {
           'AND_THIS': '{{value + value}}',
           'BLANK_VALUE': ''
         })
+        .translations('de', {
+          'TRANSLATION_ID': 'foo_de',
+          'TD_WITH_VALUE': 'Lorem Ipsum (de) {{value}}'
+        })
         .preferredLanguage('en');
     }));
 
@@ -204,6 +208,33 @@ describe('pascalprecht.translate', function () {
         $rootScope.translationId = '';
         $rootScope.$digest();
         expect(element.text()).toBe('');
+      });
+    });
+
+    describe('should handle translation when a explicit language is requested', function () {
+      it('should return translation in the correct language if translation exists and translation id is passed at attribute', function () {
+        element = $compile('<div translate="TRANSLATION_ID" translate-language="de"></div>')($rootScope);
+        $rootScope.$digest();
+        expect(element.text()).toBe('foo_de');
+      });
+
+      it('should return translation in the correct language if translation exists', function () {
+        element = $compile('<div translate translate-language="de">TRANSLATION_ID</div>')($rootScope);
+        $rootScope.$digest();
+        expect(element.text()).toBe('foo_de');
+      });
+
+      it('should return translation in the correct language if translation exists when translation is an interpolation', function () {
+        element = $compile('<div translate="TD_WITH_VALUE" translate-language="de"></div>')($rootScope);
+        $rootScope.$digest();
+        expect(element.text()).toBe('Lorem Ipsum (de) ');
+      });
+
+      it('should return translation in the correct language if translation exists when translation is an interpolation and a provided value', function () {
+        $rootScope.value = '123';
+        element = $compile('<div translate="TD_WITH_VALUE" translate-language="de" translate-values="{value: \'foo\'}"></div>')($rootScope);
+        $rootScope.$digest();
+        expect(element.text()).toBe('Lorem Ipsum (de) foo');
       });
     });
 

--- a/test/unit/filter/translate.spec.js
+++ b/test/unit/filter/translate.spec.js
@@ -147,6 +147,35 @@ describe('pascalprecht.translate', function () {
       expect($translate('FOO', {}, 'custom')).toEqual('custom interpolation');
     }));
   });
+
+  describe('request explicit language', function () {
+
+    beforeEach(module('pascalprecht.translate', function ($translateProvider, $provide) {
+
+      $translateProvider.translations('en', {
+        'FOO': 'Yesssss'
+      })
+      .translations('de', {
+        'FOO': 'Yesssss_de'
+      });
+
+      $translateProvider
+        .preferredLanguage('en');
+    }));
+
+    var $translate, $filter, $rootScope, $q;
+    beforeEach(inject(function (_$filter_, _$rootScope_, _$q_) {
+      $filter = _$filter_;
+      $rootScope = _$rootScope_;
+      $q = _$q_;
+      $translate = $filter('translate');
+    }));
+
+    it('should translate the translation ID using the requested Language Key', inject(function () {
+      expect($translate('FOO', {}, {}, 'de')).toEqual('Yesssss_de');
+    }));
+  });
+
   describe('shall add the prefix and suffix elements', function () {
 
     beforeEach(module('pascalprecht.translate', function ($translateProvider, $provide) {

--- a/test/unit/service/translate.spec.js
+++ b/test/unit/service/translate.spec.js
@@ -1607,6 +1607,10 @@ describe('pascalprecht.translate', function () {
     beforeEach(module('pascalprecht.translate', function ($translateProvider) {
       $translateProvider
         .translations('en', translationMock)
+        .translations('de', {
+          'FOO': 'bar_de',
+          'BAR': 'foo_de'
+        })
         .translations('en', {
           'FOO': 'bar',
           'BAR': 'foo'
@@ -1635,6 +1639,10 @@ describe('pascalprecht.translate', function () {
       expect($translate.instant('BLANK_VALUE')).toEqual('');
     });
 
+    it('should return translation for the explicitely requested langKey', function () {
+      expect($translate.instant('FOO', undefined, undefined, 'de')).toEqual('bar_de');
+    });
+
    it('should return translations of multiple translation ids', function () {
       var result = $translate.instant(['FOO', 'FOO2', 'BLANK_VALUE']);
       expect(result.FOO).toEqual('bar');
@@ -1654,6 +1662,9 @@ describe('pascalprecht.translate', function () {
         })
         .translations('de', {
           'FOO2': 'bar2'
+        })
+        .translations('ja', {
+          'FOO': 'bar_japan'
         })
         .preferredLanguage('de')
         .fallbackLanguage('en');
@@ -1687,6 +1698,10 @@ describe('pascalprecht.translate', function () {
 
     it('should return translation id if translation id nost exist', function () {
       expect($translate.instant('FOO3')).toEqual('FOO3');
+    });
+
+    it('should return translation for the explicitely requested langKey', function () {
+      expect($translate.instant('FOO', undefined, undefined, 'ja')).toEqual('bar_japan');
     });
 
     it('should return translation id with default interpolator if translation id nost exist', function () {


### PR DESCRIPTION
Updated unit tests to cover the new functionality
